### PR TITLE
Phase 6: Sales feature with cart, transactional checkout, and history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,17 +393,17 @@ Tareas:
 
 ## FASE 6 — Feature: Ventas
 **Branch:** `feature/phase-6-sales`
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada
 
 Objetivo: Implementar el flujo de creación de ventas con descuento de inventario.
 
 Tareas:
-- [ ] Pantalla de nueva venta: buscar y agregar productos
-- [ ] Carrito de venta con cantidades editables
-- [ ] Cálculo automático de subtotales y total
-- [ ] Al confirmar venta: crear `sale` + `sale_items` + descontar stock (transaccional)
-- [ ] Tipo de movimiento `OUT` en `inventory_movements`
-- [ ] Lista de ventas realizadas (historial básico)
+- [x] Pantalla de nueva venta: buscar y agregar productos
+- [x] Carrito de venta con cantidades editables
+- [x] Cálculo automático de subtotales y total
+- [x] Al confirmar venta: crear `sale` + `sale_items` + descontar stock (transaccional)
+- [x] Tipo de movimiento `OUT` en `inventory_movements`
+- [x] Lista de ventas realizadas (historial básico)
 
 ⸻
 
@@ -479,7 +479,7 @@ Tareas:
 | 3 | Internacionalización | `feature/phase-3-i18n` | ✅ Completada |
 | 4 | App Shell y Navegación | `feature/phase-4-app-shell` | ✅ Completada |
 | 5 | Productos (CRUD + Stock) | `feature/phase-5-products` | ✅ Completada |
-| 6 | Ventas | `feature/phase-6-sales` | ⬜ Pendiente |
+| 6 | Ventas | `feature/phase-6-sales` | ✅ Completada |
 | 7 | Consignaciones | `feature/phase-7-consignments` | ⬜ Pendiente |
 | 8 | Dashboard | `feature/phase-8-dashboard` | ⬜ Pendiente |
 | 9 | Motor de Sincronización | `feature/phase-9-sync-engine` | ⬜ Pendiente |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { ProductDetailPage } from '@/features/products/ProductDetailPage'
 import { ProductFormPage } from '@/features/products/ProductFormPage'
 import { SalesPage } from '@/features/sales/SalesPage'
 import { NewSalePage } from '@/features/sales/NewSalePage'
+import { SaleDetailPage } from '@/features/sales/SaleDetailPage'
 import { ConsignmentsPage } from '@/features/consignments/ConsignmentsPage'
 import { SettingsPage } from '@/features/settings/SettingsPage'
 
@@ -21,6 +22,7 @@ function App() {
           <Route path="/products/:id/edit" element={<ProductFormPage />} />
           <Route path="/sales" element={<SalesPage />} />
           <Route path="/sales/new" element={<NewSalePage />} />
+          <Route path="/sales/:id" element={<SaleDetailPage />} />
           <Route path="/consignments" element={<ConsignmentsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -4,7 +4,7 @@ import { BottomNav } from '@/components/BottomNav'
 import { FloatingActionButton } from '@/components/FloatingActionButton'
 import { useUIStore } from '@/stores/uiStore'
 
-const pagesWithFAB = ['/', '/products', '/dashboard']
+const pagesWithFAB = ['/', '/products', '/sales', '/dashboard']
 
 export function Layout() {
   const location = useLocation()

--- a/src/features/sales/NewSalePage.tsx
+++ b/src/features/sales/NewSalePage.tsx
@@ -1,21 +1,297 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
+import { getProducts } from '@/features/products/productService'
+import { createSale, type CartItem } from './salesService'
+import type { Product } from '@/core/db/types'
 
 export function NewSalePage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [products, setProducts] = useState<Product[]>([])
+  const [search, setSearch] = useState('')
+  const [cart, setCart] = useState<CartItem[]>([])
+  const [showSearch, setShowSearch] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const loadProducts = useCallback(async () => {
+    const results = await getProducts(search || undefined)
+    setProducts(results.filter((p) => p.active && p.stock > 0))
+  }, [search])
+
+  useEffect(() => {
+    if (showSearch) {
+      loadProducts()
+    }
+  }, [showSearch, loadProducts])
+
+  const addToCart = (product: Product) => {
+    setCart((prev) => {
+      const existing = prev.find((item) => item.product.id === product.id)
+      if (existing) {
+        return prev.map((item) =>
+          item.product.id === product.id
+            ? { ...item, quantity: item.quantity + 1 }
+            : item,
+        )
+      }
+      return [...prev, { product, quantity: 1 }]
+    })
+    setShowSearch(false)
+    setSearch('')
+  }
+
+  const updateQuantity = (productId: string, quantity: number) => {
+    if (quantity <= 0) {
+      setCart((prev) => prev.filter((item) => item.product.id !== productId))
+      return
+    }
+    setCart((prev) =>
+      prev.map((item) =>
+        item.product.id === productId ? { ...item, quantity } : item,
+      ),
+    )
+  }
+
+  const removeFromCart = (productId: string) => {
+    setCart((prev) => prev.filter((item) => item.product.id !== productId))
+  }
+
+  const total = cart.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0,
+  )
+
+  const hasInsufficientStock = cart.some(
+    (item) => item.quantity > item.product.stock,
+  )
+
+  const handleConfirmSale = async () => {
+    if (cart.length === 0 || hasInsufficientStock) return
+    setSubmitting(true)
+    try {
+      await createSale(cart)
+      navigate('/sales')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <div>
-      <PageHeader title={t('sales.newSale')} showBack />
-      <EmptyState
-        icon={
-          <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" strokeWidth={1} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
-          </svg>
+      <PageHeader
+        title={t('sales.newSale')}
+        showBack
+        action={
+          <button
+            onClick={() => setShowSearch(true)}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            + {t('sales.addProduct')}
+          </button>
         }
-        message={t('sales.emptyCart')}
       />
+
+      {/* Product search modal */}
+      {showSearch && (
+        <div className="fixed inset-0 z-50 bg-black/40 flex items-end">
+          <div className="w-full bg-white rounded-t-2xl max-h-[80vh] flex flex-col">
+            <div className="px-4 pt-4 pb-2 flex items-center gap-3">
+              <input
+                type="text"
+                placeholder={t('sales.searchProducts')}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                autoFocus
+              />
+              <button
+                onClick={() => {
+                  setShowSearch(false)
+                  setSearch('')
+                }}
+                className="text-sm text-gray-500 hover:text-gray-700"
+              >
+                {t('common.close')}
+              </button>
+            </div>
+
+            <div className="overflow-y-auto flex-1">
+              {products.length === 0 ? (
+                <p className="text-center text-sm text-gray-500 py-8">
+                  {t('common.noResults')}
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-200">
+                  {products.map((product) => {
+                    const inCart = cart.find((c) => c.product.id === product.id)
+                    return (
+                      <li key={product.id}>
+                        <button
+                          onClick={() => addToCart(product)}
+                          className="w-full px-4 py-3 flex items-center gap-3 hover:bg-gray-50 active:bg-gray-100 text-left"
+                        >
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-gray-900 truncate">
+                              {product.name}
+                            </p>
+                            <p className="text-xs text-gray-500 mt-0.5">
+                              {product.sku} &middot; {t('products.stock')}:{' '}
+                              {product.stock}
+                            </p>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <p className="text-sm font-medium text-gray-900">
+                              ${product.price.toFixed(2)}
+                            </p>
+                            {inCart && (
+                              <p className="text-xs text-blue-600 mt-0.5">
+                                {t('sales.inCart')}: {inCart.quantity}
+                              </p>
+                            )}
+                          </div>
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Cart */}
+      <div className="px-4 py-4">
+        {cart.length === 0 ? (
+          <EmptyState
+            icon={
+              <svg
+                className="w-12 h-12"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                />
+              </svg>
+            }
+            message={t('sales.emptyCart')}
+          />
+        ) : (
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-gray-700">
+              {t('sales.cart')}
+            </h2>
+
+            <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+              {cart.map((item) => {
+                const subtotal = item.product.price * item.quantity
+                const insufficientStock = item.quantity > item.product.stock
+                return (
+                  <div key={item.product.id} className="px-4 py-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate">
+                          {item.product.name}
+                        </p>
+                        <p className="text-xs text-gray-500 mt-0.5">
+                          ${item.product.price.toFixed(2)} &times;{' '}
+                          {item.quantity}
+                        </p>
+                        {insufficientStock && (
+                          <p className="text-xs text-red-600 mt-0.5">
+                            {t('sales.insufficientStock')} ({t('products.stock')}:{' '}
+                            {item.product.stock})
+                          </p>
+                        )}
+                      </div>
+                      <p className="text-sm font-medium text-gray-900 shrink-0">
+                        ${subtotal.toFixed(2)}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-2 mt-2">
+                      <button
+                        onClick={() =>
+                          updateQuantity(item.product.id, item.quantity - 1)
+                        }
+                        className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50"
+                      >
+                        &minus;
+                      </button>
+                      <input
+                        type="number"
+                        min="1"
+                        value={item.quantity}
+                        onChange={(e) =>
+                          updateQuantity(
+                            item.product.id,
+                            parseInt(e.target.value, 10) || 0,
+                          )
+                        }
+                        className="w-14 text-center text-sm border border-gray-300 rounded-lg py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                      <button
+                        onClick={() =>
+                          updateQuantity(item.product.id, item.quantity + 1)
+                        }
+                        className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50"
+                      >
+                        +
+                      </button>
+                      <button
+                        onClick={() => removeFromCart(item.product.id)}
+                        className="ml-auto p-1 text-red-500 hover:text-red-700"
+                        aria-label={t('common.delete')}
+                      >
+                        <svg
+                          className="w-5 h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth={2}
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* Total */}
+            <div className="bg-white rounded-lg border border-gray-200 px-4 py-3 flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700">
+                {t('sales.total')}
+              </span>
+              <span className="text-lg font-bold text-gray-900">
+                ${total.toFixed(2)}
+              </span>
+            </div>
+
+            {/* Confirm button */}
+            <button
+              onClick={handleConfirmSale}
+              disabled={submitting || hasInsufficientStock}
+              className="w-full px-4 py-3 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 disabled:opacity-50"
+            >
+              {submitting ? t('common.loading') : t('sales.confirmSale')}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/features/sales/SaleDetailPage.tsx
+++ b/src/features/sales/SaleDetailPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { PageHeader } from '@/components/PageHeader'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
+import { getSaleWithItems, type SaleWithItems } from './salesService'
+
+export function SaleDetailPage() {
+  const { t } = useTranslation()
+  const { id } = useParams<{ id: string }>()
+  const [sale, setSale] = useState<SaleWithItems | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (id) {
+      getSaleWithItems(id).then((result) => {
+        setSale(result ?? null)
+        setLoading(false)
+      })
+    }
+  }, [id])
+
+  const formatDate = (iso: string) => {
+    const date = new Date(iso)
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  if (loading) return <LoadingSpinner />
+  if (!sale) return null
+
+  return (
+    <div>
+      <PageHeader title={t('sales.saleDetail')} showBack />
+
+      <div className="px-4 py-4 space-y-4">
+        {/* Sale info */}
+        <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+          <div className="flex items-center justify-between px-4 py-3">
+            <span className="text-sm text-gray-500">{t('sales.date')}</span>
+            <span className="text-sm font-medium text-gray-900">
+              {formatDate(sale.created_at)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between px-4 py-3">
+            <span className="text-sm text-gray-500">{t('products.status')}</span>
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                sale.status === 'completed'
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-red-100 text-red-700'
+              }`}
+            >
+              {t(`sales.status.${sale.status}`)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between px-4 py-3">
+            <span className="text-sm text-gray-500">{t('sales.total')}</span>
+            <span className="text-lg font-bold text-gray-900">
+              ${sale.total.toFixed(2)}
+            </span>
+          </div>
+        </div>
+
+        {/* Sale items */}
+        <h2 className="text-sm font-medium text-gray-700">{t('sales.items')}</h2>
+        <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+          {sale.items.map((item) => (
+            <div key={item.id} className="px-4 py-3 flex items-center justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">
+                  {item.productName}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  ${item.unit_price.toFixed(2)} &times; {item.quantity}
+                </p>
+              </div>
+              <p className="text-sm font-medium text-gray-900 shrink-0">
+                ${item.subtotal.toFixed(2)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/sales/SalesPage.tsx
+++ b/src/features/sales/SalesPage.tsx
@@ -1,21 +1,116 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
+import { getSales } from './salesService'
+import type { Sale } from '@/core/db/types'
 
 export function SalesPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [sales, setSales] = useState<Sale[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getSales().then((results) => {
+      setSales(results)
+      setLoading(false)
+    })
+  }, [])
+
+  const formatDate = (iso: string) => {
+    const date = new Date(iso)
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
 
   return (
     <div>
-      <PageHeader title={t('sales.title')} />
-      <EmptyState
-        icon={
-          <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" strokeWidth={1} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
-          </svg>
+      <PageHeader
+        title={t('sales.title')}
+        action={
+          <button
+            onClick={() => navigate('/sales/new')}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            + {t('sales.newSale')}
+          </button>
         }
-        message={t('sales.noSales')}
       />
+
+      {loading ? (
+        <LoadingSpinner />
+      ) : sales.length === 0 ? (
+        <EmptyState
+          icon={
+            <svg
+              className="w-12 h-12"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+              />
+            </svg>
+          }
+          message={t('sales.noSales')}
+        />
+      ) : (
+        <ul className="divide-y divide-gray-200">
+          {sales.map((sale) => (
+            <li key={sale.id}>
+              <button
+                onClick={() => navigate(`/sales/${sale.id}`)}
+                className="w-full px-4 py-3 flex items-center gap-3 hover:bg-gray-50 active:bg-gray-100 text-left"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900">
+                    ${sale.total.toFixed(2)}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {formatDate(sale.created_at)}
+                  </p>
+                </div>
+
+                <span
+                  className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${
+                    sale.status === 'completed'
+                      ? 'bg-green-100 text-green-700'
+                      : 'bg-red-100 text-red-700'
+                  }`}
+                >
+                  {t(`sales.status.${sale.status}`)}
+                </span>
+
+                <svg
+                  className="w-5 h-5 text-gray-400 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="m8.25 4.5 7.5 7.5-7.5 7.5"
+                  />
+                </svg>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/src/features/sales/salesService.ts
+++ b/src/features/sales/salesService.ts
@@ -1,0 +1,114 @@
+import { db } from '@/core/db'
+import { createBaseEntity, markAsUpdated } from '@/core/db/helpers'
+import type { Sale, SaleItem, Product } from '@/core/db/types'
+import { adjustStock } from '@/features/products/productService'
+
+export interface CartItem {
+  product: Product
+  quantity: number
+}
+
+export interface SaleWithItems extends Sale {
+  items: (SaleItem & { productName: string })[]
+}
+
+/**
+ * Creates a sale transactionally: sale record + sale_items + stock deductions.
+ */
+export async function createSale(cartItems: CartItem[]): Promise<Sale> {
+  const saleBase = createBaseEntity()
+  const total = cartItems.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0,
+  )
+
+  const sale: Sale = {
+    ...saleBase,
+    total,
+    status: 'completed',
+    created_by: null,
+  }
+
+  await db.transaction(
+    'rw',
+    [db.sales, db.sale_items, db.products, db.inventory_movements],
+    async () => {
+      await db.sales.add(sale)
+
+      for (const cartItem of cartItems) {
+        const subtotal = cartItem.product.price * cartItem.quantity
+
+        const saleItem: SaleItem = {
+          ...createBaseEntity(),
+          sale_id: sale.id,
+          product_id: cartItem.product.id,
+          quantity: cartItem.quantity,
+          unit_price: cartItem.product.price,
+          subtotal,
+        }
+        await db.sale_items.add(saleItem)
+
+        await adjustStock(
+          cartItem.product.id,
+          cartItem.quantity,
+          'OUT',
+          cartItem.product.price,
+          'sale',
+          sale.id,
+        )
+      }
+    },
+  )
+
+  return sale
+}
+
+/**
+ * Fetches all non-deleted sales, sorted by most recent first.
+ */
+export async function getSales(): Promise<Sale[]> {
+  const sales = await db.sales.filter((s) => !s.deleted).toArray()
+  return sales.sort((a, b) => b.created_at.localeCompare(a.created_at))
+}
+
+/**
+ * Fetches a single sale by ID.
+ */
+export async function getSale(id: string): Promise<Sale | undefined> {
+  return db.sales.get(id)
+}
+
+/**
+ * Fetches sale items for a given sale ID.
+ */
+export async function getSaleItems(saleId: string): Promise<SaleItem[]> {
+  return db.sale_items.where('sale_id').equals(saleId).filter((i) => !i.deleted).toArray()
+}
+
+/**
+ * Fetches a sale with its items and product names.
+ */
+export async function getSaleWithItems(id: string): Promise<SaleWithItems | undefined> {
+  const sale = await db.sales.get(id)
+  if (!sale) return undefined
+
+  const items = await getSaleItems(id)
+  const itemsWithNames = await Promise.all(
+    items.map(async (item) => {
+      const product = await db.products.get(item.product_id)
+      return { ...item, productName: product?.name ?? '—' }
+    }),
+  )
+
+  return { ...sale, items: itemsWithNames }
+}
+
+/**
+ * Cancels a sale. Updates status to cancelled but does NOT revert stock.
+ */
+export async function cancelSale(id: string): Promise<void> {
+  await db.sales.update(id, {
+    status: 'cancelled' as const,
+    ...markAsUpdated(),
+  })
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -91,6 +91,12 @@
     "saleCompleted": "Sale completed",
     "saleCancelled": "Sale cancelled",
     "noSales": "No sales yet",
+    "saleDetail": "Sale Detail",
+    "items": "Items",
+    "date": "Date",
+    "searchProducts": "Search products...",
+    "insufficientStock": "Insufficient stock",
+    "inCart": "In cart",
     "status": {
       "completed": "Completed",
       "cancelled": "Cancelled"

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -91,6 +91,12 @@
     "saleCompleted": "Venta completada",
     "saleCancelled": "Venta cancelada",
     "noSales": "Aún no hay ventas",
+    "saleDetail": "Detalle de Venta",
+    "items": "Artículos",
+    "date": "Fecha",
+    "searchProducts": "Buscar productos...",
+    "insufficientStock": "Stock insuficiente",
+    "inCart": "En carrito",
     "status": {
       "completed": "Completada",
       "cancelled": "Cancelada"


### PR DESCRIPTION
- New sale screen with product search modal and cart management
- Editable quantities with +/- buttons and direct input
- Automatic subtotal and total calculation
- Transactional sale creation: sale + sale_items + stock deduction (OUT movements)
- Insufficient stock validation prevents checkout
- Sales history list with status badges and date formatting
- Sale detail page showing items breakdown
- Full i18n support (EN/ES) for all new strings
- FAB visible on sales page for quick access

https://claude.ai/code/session_016SHMojEct6NNY2zv2WKYfM