### PR TITLE
Phase 9: Bidirectional sync engine with Supabase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,17 +440,17 @@ Tareas:
 
 ## FASE 9 — Motor de Sincronización
 **Branch:** `feature/phase-9-sync-engine`
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada
 
 Objetivo: Implementar sincronización bidireccional con Supabase.
 
 Tareas:
-- [ ] **Push:** Para cada tabla, enviar registros con `synced = false` a Supabase (upsert), marcar `synced = true` on success
-- [ ] **Pull:** Para cada tabla, traer registros de Supabase donde `updated_at > lastSync`, merge local con last-write-wins
-- [ ] Almacenar `lastSync` en localStorage
-- [ ] Triggers: al iniciar app, al restaurar conexión (`online` event), cada 60 segundos
-- [ ] Indicador de estado de sincronización en la UI (Zustand store)
-- [ ] Manejo de errores: no bloquear la app si la sync falla
+- [x] **Push:** Para cada tabla, enviar registros con `synced = false` a Supabase (upsert), marcar `synced = true` on success
+- [x] **Pull:** Para cada tabla, traer registros de Supabase donde `updated_at > lastSync`, merge local con last-write-wins
+- [x] Almacenar `lastSync` en localStorage
+- [x] Triggers: al iniciar app, al restaurar conexión (`online` event), cada 60 segundos
+- [x] Indicador de estado de sincronización en la UI (Zustand store)
+- [x] Manejo de errores: no bloquear la app si la sync falla
 
 ⸻
 
@@ -482,5 +482,5 @@ Tareas:
 | 6 | Ventas | `feature/phase-6-sales` | ✅ Completada |
 | 7 | Consignaciones | `feature/phase-7-consignments` | ✅ Completada |
 | 8 | Dashboard | `feature/phase-8-dashboard` | ✅ Completada |
-| 9 | Motor de Sincronización | `feature/phase-9-sync-engine` | ⬜ Pendiente |
+| 9 | Motor de Sincronización | `feature/phase-9-sync-engine` | ✅ Completada |
 | 10 | Settings, PWA y Docs | `feature/phase-10-settings-polish` | ⬜ Pendiente |

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom'
 import { BottomNav } from '@/components/BottomNav'
 import { FloatingActionButton } from '@/components/FloatingActionButton'
 import { useUIStore } from '@/stores/uiStore'
+import { useSync } from '@/hooks/useSync'
 
 const pagesWithFAB = ['/', '/products', '/sales', '/dashboard']
 
@@ -10,6 +11,9 @@ export function Layout() {
   const location = useLocation()
   const setIsOnline = useUIStore((s) => s.setIsOnline)
   const showFAB = pagesWithFAB.includes(location.pathname)
+
+  // Start sync engine (initial sync, 60s interval, online reconnection)
+  useSync()
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true)

--- a/src/core/sync/index.ts
+++ b/src/core/sync/index.ts
@@ -1,0 +1,1 @@
+export { runSync, startSyncEngine } from './syncEngine';

--- a/src/core/sync/pullSync.ts
+++ b/src/core/sync/pullSync.ts
@@ -1,0 +1,72 @@
+import type { Table } from 'dexie';
+import { db } from '../db';
+import { supabase } from '../supabase/client';
+import type { BaseEntity } from '../db/types';
+
+interface TableConfig {
+  name: string;
+  table: Table<BaseEntity, string>;
+}
+
+/**
+ * Tables ordered by FK dependencies: parents before children.
+ */
+const TABLES: TableConfig[] = [
+  { name: 'products', table: db.products as unknown as Table<BaseEntity, string> },
+  { name: 'inventory_movements', table: db.inventory_movements as unknown as Table<BaseEntity, string> },
+  { name: 'sales', table: db.sales as unknown as Table<BaseEntity, string> },
+  { name: 'sale_items', table: db.sale_items as unknown as Table<BaseEntity, string> },
+  { name: 'consignments', table: db.consignments as unknown as Table<BaseEntity, string> },
+  { name: 'consignment_items', table: db.consignment_items as unknown as Table<BaseEntity, string> },
+];
+
+const PAGE_SIZE = 500;
+
+/**
+ * Pull records from Supabase that have been updated since lastSync.
+ * Applies last-write-wins: server record wins unless the local record
+ * has pending changes (synced = false).
+ */
+export async function pullSync(lastSync: string): Promise<void> {
+  for (const { name, table } of TABLES) {
+    let from = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const { data, error } = await supabase
+        .from(name)
+        .select('*')
+        .gt('updated_at', lastSync)
+        .order('updated_at', { ascending: true })
+        .range(from, from + PAGE_SIZE - 1);
+
+      if (error) {
+        console.error(`[Sync Pull] Error fetching ${name}:`, error.message);
+        throw new Error(`Pull failed for ${name}: ${error.message}`);
+      }
+
+      if (!data || data.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      await db.transaction('rw', table, async () => {
+        for (const remote of data) {
+          const local = await table.get(remote.id);
+
+          if (local && !local.synced) {
+            // Local record has pending changes — skip (will be pushed next cycle).
+            // Last-write-wins: local unsynced changes take priority for now.
+            continue;
+          }
+
+          // Insert or overwrite with server data, marked as synced
+          await table.put({ ...remote, synced: true } as BaseEntity);
+        }
+      });
+
+      hasMore = data.length === PAGE_SIZE;
+      from += PAGE_SIZE;
+    }
+  }
+}

--- a/src/core/sync/pushSync.ts
+++ b/src/core/sync/pushSync.ts
@@ -1,0 +1,77 @@
+import type { Table } from 'dexie';
+import { db } from '../db';
+import { supabase } from '../supabase/client';
+import type { BaseEntity } from '../db/types';
+
+interface TableConfig {
+  name: string;
+  table: Table<BaseEntity, string>;
+}
+
+/**
+ * Tables ordered by FK dependencies: parents before children.
+ */
+const TABLES: TableConfig[] = [
+  { name: 'products', table: db.products as unknown as Table<BaseEntity, string> },
+  { name: 'inventory_movements', table: db.inventory_movements as unknown as Table<BaseEntity, string> },
+  { name: 'sales', table: db.sales as unknown as Table<BaseEntity, string> },
+  { name: 'sale_items', table: db.sale_items as unknown as Table<BaseEntity, string> },
+  { name: 'consignments', table: db.consignments as unknown as Table<BaseEntity, string> },
+  { name: 'consignment_items', table: db.consignment_items as unknown as Table<BaseEntity, string> },
+];
+
+const BATCH_SIZE = 50;
+
+/**
+ * Push all locally modified records (synced = false) to Supabase.
+ * Processes tables in FK-dependency order and batches upserts.
+ */
+export async function pushSync(): Promise<void> {
+  for (const { name, table } of TABLES) {
+    const unsynced = await table
+      .where('synced')
+      .equals(0) // Dexie stores booleans as 0/1
+      .toArray();
+
+    if (unsynced.length === 0) continue;
+
+    // Process in batches
+    for (let i = 0; i < unsynced.length; i += BATCH_SIZE) {
+      const batch = unsynced.slice(i, i + BATCH_SIZE);
+
+      // Prepare records for Supabase: set synced = true on server
+      const records = batch.map((record) => ({
+        ...record,
+        synced: true,
+      }));
+
+      const { data, error } = await supabase
+        .from(name)
+        .upsert(records, { onConflict: 'id' })
+        .select('id, updated_at');
+
+      if (error) {
+        console.error(`[Sync Push] Error upserting to ${name}:`, error.message);
+        throw new Error(`Push failed for ${name}: ${error.message}`);
+      }
+
+      // Update local records with server timestamps and mark as synced
+      if (data && data.length > 0) {
+        const updates = data.map((row: { id: string; updated_at: string }) => ({
+          id: row.id,
+          updated_at: row.updated_at,
+          synced: true,
+        }));
+
+        await db.transaction('rw', table, async () => {
+          for (const update of updates) {
+            await table.update(update.id, {
+              synced: true,
+              updated_at: update.updated_at,
+            } as Partial<BaseEntity>);
+          }
+        });
+      }
+    }
+  }
+}

--- a/src/core/sync/syncEngine.ts
+++ b/src/core/sync/syncEngine.ts
@@ -1,0 +1,91 @@
+import { pushSync } from './pushSync';
+import { pullSync } from './pullSync';
+import { useUIStore } from '../../stores/uiStore';
+
+const LAST_SYNC_KEY = 'lastSync';
+const SYNC_INTERVAL_MS = 60_000; // 60 seconds
+
+let syncIntervalId: ReturnType<typeof setInterval> | null = null;
+let isSyncing = false;
+
+function getLastSync(): string {
+  return localStorage.getItem(LAST_SYNC_KEY) || '1970-01-01T00:00:00.000Z';
+}
+
+function setLastSync(timestamp: string): void {
+  localStorage.setItem(LAST_SYNC_KEY, timestamp);
+}
+
+/**
+ * Run a full sync cycle: push local changes, then pull remote changes.
+ * Non-blocking — errors are caught and surfaced via the UI store.
+ */
+export async function runSync(): Promise<void> {
+  if (isSyncing) return;
+
+  const { setSyncStatus, setLastSyncTime } = useUIStore.getState();
+
+  // Don't attempt sync if offline
+  if (!navigator.onLine) return;
+
+  isSyncing = true;
+  setSyncStatus('syncing');
+
+  try {
+    const syncStart = new Date().toISOString();
+    const lastSync = getLastSync();
+
+    // Phase 1: Push local changes to server
+    await pushSync();
+
+    // Phase 2: Pull remote changes
+    await pullSync(lastSync);
+
+    // Update lastSync timestamp
+    setLastSync(syncStart);
+    setLastSyncTime(syncStart);
+    setSyncStatus('success');
+  } catch (error) {
+    console.error('[Sync] Sync cycle failed:', error);
+    setSyncStatus('error');
+  } finally {
+    isSyncing = false;
+  }
+}
+
+/**
+ * Start the automatic sync engine:
+ * - Run an immediate sync
+ * - Set up a 60-second interval
+ * - Listen for online events to sync on reconnection
+ */
+export function startSyncEngine(): () => void {
+  // Initialize lastSyncTime in store from localStorage
+  const stored = localStorage.getItem(LAST_SYNC_KEY);
+  if (stored) {
+    useUIStore.getState().setLastSyncTime(stored);
+  }
+
+  // Initial sync
+  runSync();
+
+  // Periodic sync every 60 seconds
+  syncIntervalId = setInterval(() => {
+    runSync();
+  }, SYNC_INTERVAL_MS);
+
+  // Sync when connection is restored
+  const handleOnline = () => {
+    runSync();
+  };
+  window.addEventListener('online', handleOnline);
+
+  // Return cleanup function
+  return () => {
+    if (syncIntervalId !== null) {
+      clearInterval(syncIntervalId);
+      syncIntervalId = null;
+    }
+    window.removeEventListener('online', handleOnline);
+  };
+}

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,13 +1,23 @@
 import { useTranslation } from 'react-i18next'
 import { PageHeader } from '@/components/PageHeader'
 import { useUIStore } from '@/stores/uiStore'
+import { runSync } from '@/core/sync'
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation()
-  const { isOnline, syncStatus } = useUIStore()
+  const { isOnline, syncStatus, lastSyncTime } = useUIStore()
 
   const changeLanguage = (lng: string) => {
     i18n.changeLanguage(lng)
+  }
+
+  const handleSync = () => {
+    runSync()
+  }
+
+  const formatLastSync = (time: string | null): string => {
+    if (!time) return t('settings.never')
+    return new Date(time).toLocaleString(i18n.language)
   }
 
   return (
@@ -52,14 +62,21 @@ export function SettingsPage() {
               className={`w-2.5 h-2.5 rounded-full ${isOnline ? 'bg-green-500' : 'bg-gray-400'}`}
             />
           </div>
+          {syncStatus === 'success' && (
+            <p className="text-xs text-green-600 mb-2">{t('settings.syncSuccess')}</p>
+          )}
+          {syncStatus === 'error' && (
+            <p className="text-xs text-red-600 mb-2">{t('settings.syncError')}</p>
+          )}
           <button
+            onClick={handleSync}
             disabled={syncStatus === 'syncing'}
             className="w-full py-2 px-3 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:opacity-50 transition-colors"
           >
             {syncStatus === 'syncing' ? t('settings.syncing') : t('settings.syncNow')}
           </button>
           <p className="text-xs text-gray-400 mt-2">
-            {t('settings.lastSync')}: {t('settings.never')}
+            {t('settings.lastSync')}: {formatLastSync(lastSyncTime)}
           </p>
         </section>
       </div>

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { startSyncEngine } from '../core/sync';
+
+/**
+ * Hook that starts the sync engine on mount and cleans up on unmount.
+ * Should be called once in the root layout.
+ */
+export function useSync(): void {
+  useEffect(() => {
+    const cleanup = startSyncEngine();
+    return cleanup;
+  }, []);
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -5,13 +5,17 @@ type SyncStatus = 'idle' | 'syncing' | 'success' | 'error'
 interface UIState {
   syncStatus: SyncStatus
   isOnline: boolean
+  lastSyncTime: string | null
   setSyncStatus: (status: SyncStatus) => void
   setIsOnline: (online: boolean) => void
+  setLastSyncTime: (time: string) => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
   syncStatus: 'idle',
   isOnline: navigator.onLine,
+  lastSyncTime: null,
   setSyncStatus: (status) => set({ syncStatus: status }),
   setIsOnline: (online) => set({ isOnline: online }),
+  setLastSyncTime: (time) => set({ lastSyncTime: time }),
 }))


### PR DESCRIPTION
Implement offline-first synchronization engine that:
- Pushes unsynced local records to Supabase (batched upserts in FK order)
- Pulls remote changes since lastSync with last-write-wins merge
- Stores lastSync timestamp in localStorage
- Triggers automatically on app start, every 60s, and on reconnection
- Surfaces sync status (idle/syncing/success/error) via Zustand store
- Wires Settings page sync button and last sync time display
- Handles errors gracefully without blocking the app

https://claude.ai/code/session_01NgEG5sGt7QxFBhgbnmnNvy