### PR TITLE
Add authentication requirement with Google OAuth as primary login

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Layout } from './Layout'
+import { ProtectedRoute } from '@/components/ProtectedRoute'
+import { LoginPage } from '@/features/auth/LoginPage'
 import { DashboardPage } from '@/features/dashboard/DashboardPage'
 import { ProductsPage } from '@/features/products/ProductsPage'
 import { ProductDetailPage } from '@/features/products/ProductDetailPage'
@@ -11,12 +14,25 @@ import { ConsignmentsPage } from '@/features/consignments/ConsignmentsPage'
 import { NewConsignmentPage } from '@/features/consignments/NewConsignmentPage'
 import { ConsignmentDetailPage } from '@/features/consignments/ConsignmentDetailPage'
 import { SettingsPage } from '@/features/settings/SettingsPage'
+import { initAuthListener } from '@/core/supabase/auth'
 
 function App() {
+  useEffect(() => {
+    const unsubscribe = initAuthListener()
+    return unsubscribe
+  }, [])
+
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<Layout />}>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          element={
+            <ProtectedRoute>
+              <Layout />
+            </ProtectedRoute>
+          }
+        >
           <Route path="/" element={<DashboardPage />} />
           <Route path="/products" element={<ProductsPage />} />
           <Route path="/products/new" element={<ProductFormPage />} />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+import { LoadingSpinner } from './LoadingSpinner'
+
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuthStore()
+
+  if (loading) {
+    return (
+      <div className="min-h-dvh flex items-center justify-center bg-gray-50">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <>{children}</>
+}

--- a/src/core/supabase/auth.ts
+++ b/src/core/supabase/auth.ts
@@ -1,0 +1,70 @@
+import { supabase } from './client'
+import { useAuthStore } from '@/stores/authStore'
+
+/**
+ * Sign up a new user with email and password.
+ */
+export async function signUp(email: string, password: string) {
+  const { data, error } = await supabase.auth.signUp({ email, password })
+  if (error) throw error
+  return data
+}
+
+/**
+ * Sign in with email and password.
+ */
+export async function signIn(email: string, password: string) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  })
+  if (error) throw error
+  return data
+}
+
+/**
+ * Sign in with Google OAuth via Supabase.
+ */
+export async function signInWithGoogle() {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: window.location.origin,
+    },
+  })
+  if (error) throw error
+}
+
+/**
+ * Sign out the current user.
+ */
+export async function signOut() {
+  const { error } = await supabase.auth.signOut()
+  if (error) throw error
+  useAuthStore.getState().clear()
+}
+
+/**
+ * Initialize the auth listener. Call once at app startup.
+ * Returns an unsubscribe function.
+ */
+export function initAuthListener(): () => void {
+  const { setAuth, setLoading } = useAuthStore.getState()
+
+  // Check existing session
+  setLoading(true)
+  supabase.auth.getSession().then(({ data: { session } }) => {
+    setAuth(session)
+  })
+
+  // Listen for auth state changes
+  const {
+    data: { subscription },
+  } = supabase.auth.onAuthStateChange((_event, session) => {
+    setAuth(session)
+  })
+
+  return () => {
+    subscription.unsubscribe()
+  }
+}

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { signIn, signUp, signInWithGoogle } from '@/core/supabase/auth'
+
+export function LoginPage() {
+  const { t, i18n } = useTranslation()
+  const [showEmailForm, setShowEmailForm] = useState(false)
+  const [isRegister, setIsRegister] = useState(false)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [registered, setRegistered] = useState(false)
+
+  const handleGoogleSignIn = async () => {
+    setError(null)
+    setLoading(true)
+    try {
+      await signInWithGoogle()
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t('auth.unknownError')
+      setError(message)
+      setLoading(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (isRegister && password !== confirmPassword) {
+      setError(t('auth.passwordMismatch'))
+      return
+    }
+
+    if (password.length < 6) {
+      setError(t('auth.passwordTooShort'))
+      return
+    }
+
+    setLoading(true)
+    try {
+      if (isRegister) {
+        await signUp(email, password)
+        setRegistered(true)
+      } else {
+        await signIn(email, password)
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t('auth.unknownError')
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const toggleLanguage = () => {
+    i18n.changeLanguage(i18n.language === 'en' ? 'es' : 'en')
+  }
+
+  if (registered) {
+    return (
+      <div className="min-h-dvh bg-gray-50 flex items-center justify-center px-4">
+        <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-6 text-center">
+          <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="w-6 h-6 text-green-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="m4.5 12.75 6 6 9-13.5"
+              />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">
+            {t('auth.registrationSuccess')}
+          </h2>
+          <p className="text-sm text-gray-600 mb-4">
+            {t('auth.checkEmail')}
+          </p>
+          <button
+            onClick={() => {
+              setRegistered(false)
+              setIsRegister(false)
+              setShowEmailForm(false)
+            }}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            {t('auth.backToLogin')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-dvh bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        {/* Language toggle */}
+        <div className="flex justify-end mb-4">
+          <button
+            onClick={toggleLanguage}
+            className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded border border-gray-200"
+          >
+            {i18n.language === 'en' ? 'ES' : 'EN'}
+          </button>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+          {/* Header */}
+          <div className="text-center mb-6">
+            <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+              <svg
+                className="w-6 h-6 text-blue-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z"
+                />
+              </svg>
+            </div>
+            <h1 className="text-xl font-bold text-gray-900">
+              {t('app.name')}
+            </h1>
+            <p className="text-sm text-gray-500 mt-1">
+              {t('auth.signInTitle')}
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-4">
+              {error}
+            </p>
+          )}
+
+          {/* Google OAuth - Primary */}
+          <button
+            onClick={handleGoogleSignIn}
+            disabled={loading}
+            className="w-full flex items-center justify-center gap-3 px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            {t('auth.continueWithGoogle')}
+          </button>
+
+          {/* Divider */}
+          <div className="flex items-center gap-3 my-5">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-xs text-gray-400">{t('auth.or')}</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+
+          {!showEmailForm ? (
+            <button
+              onClick={() => setShowEmailForm(true)}
+              className="w-full px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+            >
+              {t('auth.continueWithEmail')}
+            </button>
+          ) : (
+            <>
+              {/* Email/Password Form */}
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    {t('auth.email')}
+                  </label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    className="input"
+                    placeholder={t('auth.emailPlaceholder')}
+                    autoComplete="email"
+                    autoFocus
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    {t('auth.password')}
+                  </label>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    className="input"
+                    placeholder={t('auth.passwordPlaceholder')}
+                    autoComplete={
+                      isRegister ? 'new-password' : 'current-password'
+                    }
+                  />
+                </div>
+
+                {isRegister && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      {t('auth.confirmPassword')}
+                    </label>
+                    <input
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      required
+                      className="input"
+                      placeholder={t('auth.confirmPasswordPlaceholder')}
+                      autoComplete="new-password"
+                    />
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full px-4 py-2.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                >
+                  {loading
+                    ? t('common.loading')
+                    : isRegister
+                      ? t('auth.register')
+                      : t('auth.login')}
+                </button>
+              </form>
+
+              {/* Toggle register/login */}
+              <div className="mt-4 text-center">
+                <button
+                  onClick={() => {
+                    setIsRegister(!isRegister)
+                    setError(null)
+                  }}
+                  className="text-sm text-blue-600 hover:text-blue-700"
+                >
+                  {isRegister ? t('auth.haveAccount') : t('auth.noAccount')}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/products/ProductFormPage.tsx
+++ b/src/features/products/ProductFormPage.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { PageHeader } from '@/components/PageHeader'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
+import { useAuthStore } from '@/stores/authStore'
 import { getProduct, createProduct, updateProduct } from './productService'
 
 interface ProductFormData {
@@ -38,6 +39,7 @@ export function ProductFormPage() {
   const { id } = useParams<{ id: string }>()
   const isEdit = Boolean(id)
   const [loading, setLoading] = useState(isEdit)
+  const organizationId = useAuthStore((s) => s.organizationId)
   const schema = useProductSchema()
 
   const {
@@ -84,7 +86,7 @@ export function ProductFormPage() {
     } else {
       await createProduct({
         ...data,
-        organization_id: 'default',
+        organization_id: organizationId!,
       })
     }
     navigate('/products')

--- a/src/features/products/productService.ts
+++ b/src/features/products/productService.ts
@@ -1,6 +1,7 @@
 import { db } from '@/core/db'
 import { createBaseEntity, markAsUpdated, markAsDeleted } from '@/core/db/helpers'
 import type { Product, InventoryMovement, InventoryMovementType } from '@/core/db/types'
+import { useAuthStore } from '@/stores/authStore'
 
 export interface CreateProductInput {
   organization_id: string
@@ -78,7 +79,7 @@ export async function createProduct(input: CreateProductInput): Promise<Product>
         unit_price: product.cost,
         reference_type: 'initial_stock',
         reference_id: null,
-        created_by: null,
+        created_by: useAuthStore.getState().user?.id ?? null,
       }
       await db.inventory_movements.add(movement)
     }
@@ -148,7 +149,7 @@ export async function adjustStock(
       unit_price: unitPrice,
       reference_type: referenceType ?? null,
       reference_id: referenceId ?? null,
-      created_by: null,
+      created_by: useAuthStore.getState().user?.id ?? null,
     }
     await db.inventory_movements.add(movement)
   })

--- a/src/features/sales/salesService.ts
+++ b/src/features/sales/salesService.ts
@@ -2,6 +2,7 @@ import { db } from '@/core/db'
 import { createBaseEntity, markAsUpdated } from '@/core/db/helpers'
 import type { Sale, SaleItem, Product } from '@/core/db/types'
 import { adjustStock } from '@/features/products/productService'
+import { useAuthStore } from '@/stores/authStore'
 
 export interface CartItem {
   product: Product
@@ -26,7 +27,7 @@ export async function createSale(cartItems: CartItem[]): Promise<Sale> {
     ...saleBase,
     total,
     status: 'completed',
-    created_by: null,
+    created_by: useAuthStore.getState().user?.id ?? null,
   }
 
   await db.transaction(

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,11 +1,18 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { PageHeader } from '@/components/PageHeader'
 import { useUIStore } from '@/stores/uiStore'
+import { useAuthStore } from '@/stores/authStore'
 import { runSync } from '@/core/sync'
+import { signOut } from '@/core/supabase/auth'
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation()
+  const navigate = useNavigate()
   const { isOnline, syncStatus, lastSyncTime } = useUIStore()
+  const user = useAuthStore((s) => s.user)
+  const [loggingOut, setLoggingOut] = useState(false)
 
   const changeLanguage = (lng: string) => {
     i18n.changeLanguage(lng)
@@ -13,6 +20,16 @@ export function SettingsPage() {
 
   const handleSync = () => {
     runSync()
+  }
+
+  const handleLogout = async () => {
+    setLoggingOut(true)
+    try {
+      await signOut()
+      navigate('/login', { replace: true })
+    } catch {
+      setLoggingOut(false)
+    }
   }
 
   const formatLastSync = (time: string | null): string => {
@@ -24,6 +41,19 @@ export function SettingsPage() {
     <div>
       <PageHeader title={t('settings.title')} />
       <div className="p-4 space-y-6">
+        {/* Account */}
+        <section className="bg-white rounded-xl p-4 shadow-sm border border-gray-100">
+          <h2 className="text-sm font-medium text-gray-900 mb-3">{t('settings.account')}</h2>
+          <p className="text-sm text-gray-600 mb-3">{user?.email}</p>
+          <button
+            onClick={handleLogout}
+            disabled={loggingOut}
+            className="w-full py-2 px-3 rounded-lg text-sm font-medium text-red-600 bg-red-50 hover:bg-red-100 disabled:opacity-50 transition-colors"
+          >
+            {loggingOut ? t('common.loading') : t('settings.logout')}
+          </button>
+        </section>
+
         {/* Language */}
         <section className="bg-white rounded-xl p-4 shadow-sm border border-gray-100">
           <h2 className="text-sm font-medium text-gray-900 mb-3">{t('settings.language')}</h2>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -127,8 +127,33 @@
       "customerNameRequired": "Customer name is required"
     }
   },
+  "auth": {
+    "signInTitle": "Sign in to your account",
+    "createAccount": "Create a new account",
+    "email": "Email",
+    "emailPlaceholder": "you@example.com",
+    "password": "Password",
+    "passwordPlaceholder": "Your password",
+    "confirmPassword": "Confirm Password",
+    "confirmPasswordPlaceholder": "Repeat your password",
+    "login": "Sign In",
+    "register": "Create Account",
+    "haveAccount": "Already have an account? Sign in",
+    "noAccount": "Don't have an account? Create one",
+    "passwordMismatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 6 characters",
+    "unknownError": "An unexpected error occurred",
+    "registrationSuccess": "Account created!",
+    "checkEmail": "Check your email to confirm your account before signing in.",
+    "backToLogin": "Back to Sign In",
+    "continueWithGoogle": "Continue with Google",
+    "continueWithEmail": "Continue with email",
+    "or": "or"
+  },
   "settings": {
     "title": "Settings",
+    "account": "Account",
+    "logout": "Sign Out",
     "language": "Language",
     "languages": {
       "en": "English",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -127,8 +127,33 @@
       "customerNameRequired": "El nombre del cliente es obligatorio"
     }
   },
+  "auth": {
+    "signInTitle": "Inicia sesión en tu cuenta",
+    "createAccount": "Crear una cuenta nueva",
+    "email": "Correo electrónico",
+    "emailPlaceholder": "tu@ejemplo.com",
+    "password": "Contraseña",
+    "passwordPlaceholder": "Tu contraseña",
+    "confirmPassword": "Confirmar Contraseña",
+    "confirmPasswordPlaceholder": "Repite tu contraseña",
+    "login": "Iniciar Sesión",
+    "register": "Crear Cuenta",
+    "haveAccount": "¿Ya tienes cuenta? Inicia sesión",
+    "noAccount": "¿No tienes cuenta? Crea una",
+    "passwordMismatch": "Las contraseñas no coinciden",
+    "passwordTooShort": "La contraseña debe tener al menos 6 caracteres",
+    "unknownError": "Ocurrió un error inesperado",
+    "registrationSuccess": "¡Cuenta creada!",
+    "checkEmail": "Revisa tu correo electrónico para confirmar tu cuenta antes de iniciar sesión.",
+    "backToLogin": "Volver a Iniciar Sesión",
+    "continueWithGoogle": "Continuar con Google",
+    "continueWithEmail": "Continuar con correo",
+    "or": "o"
+  },
   "settings": {
     "title": "Ajustes",
+    "account": "Cuenta",
+    "logout": "Cerrar Sesión",
     "language": "Idioma",
     "languages": {
       "en": "Inglés",

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand'
+import type { User, Session } from '@supabase/supabase-js'
+
+interface AuthState {
+  user: User | null
+  session: Session | null
+  organizationId: string | null
+  loading: boolean
+  setAuth: (session: Session | null) => void
+  clear: () => void
+  setLoading: (loading: boolean) => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  session: null,
+  organizationId: null,
+  loading: true,
+  setAuth: (session) =>
+    set({
+      session,
+      user: session?.user ?? null,
+      organizationId:
+        session?.user?.user_metadata?.organization_id ??
+        session?.user?.id ??
+        null,
+      loading: false,
+    }),
+  clear: () =>
+    set({
+      user: null,
+      session: null,
+      organizationId: null,
+      loading: false,
+    }),
+  setLoading: (loading) => set({ loading }),
+}))


### PR DESCRIPTION
The app was previously accessible without any login, making it impossible
to identify users or isolate data per organization. This adds:

- Auth store (Zustand) for session state management
- Supabase auth service (Google OAuth, email/password, session listener)
- Login page with Google as primary method and email as fallback
- ProtectedRoute component guarding all app routes
- organization_id and created_by now derived from authenticated user
- Logout option in Settings page
- Bilingual auth translations (en/es)

https://claude.ai/code/session_01XHotz5fHMQaHtiwmXtLy7o